### PR TITLE
sc 154156/update node js server side sdk hello app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
-### LaunchDarkly Sample TypeScript Node.js Application ###
-We've built a simple console application that demonstrates how LaunchDarkly's SDK works. Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/).
+# LaunchDarkly sample TypeScript Node.js (server-side) application
 
-##### Build instructions #####
+We've built a simple console application that demonstrates how LaunchDarkly's SDK works.
+
+ Below, you'll find the build procedure. For more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Node.js (server-side) reference guide](https://docs.launchdarkly.com/sdk/server-side/node-js).
+
+The LaunchDarkly server-side SDK for Node.js is designed primarily for use in multi-user systems such as web servers and applications. It follows the server-side LaunchDarkly model for multi-user contexts. It is not intended for use in desktop and embedded systems applications.
+
+For a sample application demonstrating how to use LaunchDarkly in *client-side* Node.js applications, refer to our [Client-side Node.js SDK sample application](https://github.com/launchdarkly/hello-node-client).
+
+## Build instructions
+
 1. Install the LaunchDarkly Node.js SDK by running `npm install`
-2. Copy your API key and feature flag key from your LaunchDarkly dashboard into `index.ts`
+2. Edit `index.ts` and set the value of `sdkKey` to your LaunchDarkly SDK key. If there is an existing boolean feature flag in your LaunchDarkly project that you want to evaluate, set `featureFlagKey` to the flag key.
+
+```js
+  const sdkKey = "1234567890abcdef";
+
+  const featureFlagKey = "my-flag";
+```
+
 3. Run `npm start`

--- a/index.ts
+++ b/index.ts
@@ -6,8 +6,6 @@ const sdkKey = "";
 // Set featureFlagKey to the feature flag key you want to evaluate.
 const featureFlagKey = "my-boolean-flag";
 
-const client = LaunchDarkly.init(sdkKey);
-
 // Set up the user properties. This use should appear on your LaunchDarkly
 // users dashboard soon after you run the demo.
 const user = {
@@ -15,17 +13,30 @@ const user = {
    "key": "example-user-key"
 };
 
+function showMessage(s: string) {
+  console.log("*** " + s);
+  console.log("");
+}
+
+const client = LaunchDarkly.init(sdkKey);
+
 client.once('ready', function() {
-  // TODO : Enter the key for your feature flag here
-  client.variation("enable-pinning", user, false, function(err, showFeature) {
+  showMessage("SDK successfully initialized!");
+  client.variation(featureFlagKey, user, false, function(err, showFeature) {
     client.track("event-called", user);
     if (showFeature) {
       // application code to show the feature
-      console.log("Showing your feature to " + user.key );
+      showMessage("Feature flag '" + featureFlagKey + "' is true for this user");
     } else {
-      // the code to run if the feature is off 
-      console.log("Not showing your feature to " + user.key);
+      // the code to run if the feature is off
+      showMessage("Feature flag '" + featureFlagKey + "' is false for this user");
     }
+
+    // Here we ensure that the SDK shuts down cleanly and has a chance to deliver analytics
+    // events to LaunchDarkly before the program exits. If analytics events are not delivered,
+    // the user properties and flag usage statistics will not appear on your dashboard. In a
+    // normal long-running application, the SDK would continue running and events would be
+    // delivered automatically in the background.
     client.flush(function() {
       client.close();
     });

--- a/index.ts
+++ b/index.ts
@@ -1,15 +1,18 @@
 import * as LaunchDarkly from 'launchdarkly-node-server-sdk';
 
-// TODO : Enter your LaunchDarkly SDK key here
-const client = LaunchDarkly.init("YOUR_SDK_KEY");
+// Set sdkKey to your LaunchDarkly SDK key.
+const sdkKey = "";
 
+// Set featureFlagKey to the feature flag key you want to evaluate.
+const featureFlagKey = "my-boolean-flag";
+
+const client = LaunchDarkly.init(sdkKey);
+
+// Set up the user properties. This use should appear on your LaunchDarkly
+// users dashboard soon after you run the demo.
 const user = {
-   "firstName":"Bob",
-   "lastName":"Loblaw",
-   "key":"louise@example.com",
-   "custom":{
-      "groups":"beta_testers"
-   }
+   "name": "Sandy",
+   "key": "example-user-key"
 };
 
 client.once('ready', function() {


### PR DESCRIPTION
[SC-154156](https://app.shortcut.com/launchdarkly/story/154156/update-node-js-server-side-sdk-hello-app-readme-and-comments-to-standard-design): After receiving some feedback that it'd be helpful if the Hello apps were more standardized, Docs team is working on updating them to [match the spec](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/1499562073/SDK+hello+world).

For this app, some readme updates (including adding the cautions/clarifications on Node.js client-side vs. server-side that are in the [hello-node-server](https://github.com/launchdarkly/hello-node-server) readme), turning some hardcoded strings into variables w/ standard values, and adding standard comments.