### PR TITLE
ci: replace common-workflows reusable workflow with gh-actions composite actions

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -7,9 +7,24 @@ on:
       - main
 
 jobs:
-  dependency-scan:
-    uses: launchdarkly/common-workflows/.github/workflows/dependency-scan.yml@main
-    with:
-      types: 'nodejs'
-      runs-on: 'ubuntu-latest'
-    secrets: inherit
+  generate-nodejs-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Generate SBOM
+        uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@main
+        with:
+          types: 'nodejs'
+
+  evaluate-policy:
+    runs-on: ubuntu-latest
+    needs:
+      - generate-nodejs-sbom
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Evaluate SBOM Policy
+        uses: launchdarkly/gh-actions/actions/dependency-scan/evaluate-policy@main
+        with:
+          artifacts-pattern: bom-*


### PR DESCRIPTION
## Summary

Replaces the `launchdarkly/common-workflows/.github/workflows/dependency-scan.yml@main` reusable workflow with the composite actions from [`launchdarkly/gh-actions/actions/dependency-scan/`](https://github.com/launchdarkly/gh-actions/tree/main/actions/dependency-scan). The new workflow uses two explicit jobs (`generate-nodejs-sbom` → `evaluate-policy`), matching the pattern already adopted by other SDK repos (e.g., `js-client-sdk`, `js-core`, `openfeature-node-server`).

A similar change is being made in `launchdarkly/react-client-sdk`.

## Review & Testing Checklist for Human
- [ ] Verify the `Dependency Scan` workflow passes on this PR (both `generate-nodejs-sbom` and `evaluate-policy` jobs)
- [ ] Confirm the workflow structure matches other already-migrated SDK repos

### Notes
- The `common-workflows` repo appears to no longer be accessible (returns 404), so the previous workflow reference may already be broken.
- The `actions/checkout` SHA (`08eba0b2...`) is pinned to v4, consistent with other SDK repos using these actions.

Link to Devin session: https://app.devin.ai/sessions/2783d2578c67461aa0af3b814ea886b2
Requested by: @kinyoklion