### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Repository Maintainers
+* @launchdarkly/team-sdk-js


### PR DESCRIPTION
## Summary

Add CODEOWNERS file assigning `@launchdarkly/team-sdk-js` as repository maintainers, consistent with the `js-core` repo.

Link to Devin session: https://app.devin.ai/sessions/093ea87681b74023a0a8f62e9c7e6d5a
Requested by: @kinyoklion