### PR TITLE
chore: update @launchdarkly/node-server-sdk minimum to 9.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "typescript": "5.7.2"
   },
   "dependencies": {
-    "@launchdarkly/node-server-sdk": ">= 9.0.0"
+    "@launchdarkly/node-server-sdk": ">= 9.11.3"
   }
 }


### PR DESCRIPTION
## Summary

Updates the `@launchdarkly/node-server-sdk` minimum version constraint from `>= 9.0.0` to `>= 9.11.3`.

No deprecated APIs were found in the example code. The app builds and runs successfully with the latest SDK version.

Link to Devin session: https://app.devin.ai/sessions/cc589fb7edf04b2280685cb10c9bb431
Requested by: @kinyoklion